### PR TITLE
Remove 'use strict' since js modules add them.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,4 +1,3 @@
-'use strict';
 import Cycle from 'cyclejs';
 import './components/todo-item';
 import source from './sources/todos';

--- a/src/components/todo-item.js
+++ b/src/components/todo-item.js
@@ -1,4 +1,3 @@
-'use strict';
 import Cycle from 'cyclejs';
 let {Rx, h} = Cycle;
 import {propHook, ENTER_KEY, ESC_KEY} from '../utils';

--- a/src/intents/todos.js
+++ b/src/intents/todos.js
@@ -1,4 +1,3 @@
-'use strict';
 import Cycle from 'cyclejs';
 import {ENTER_KEY, ESC_KEY} from '../utils';
 

--- a/src/models/todos.js
+++ b/src/models/todos.js
@@ -1,4 +1,3 @@
-'use strict';
 import Cycle from 'cyclejs';
 
 function getFilterFn(route) {

--- a/src/sinks/local-storage.js
+++ b/src/sinks/local-storage.js
@@ -1,5 +1,3 @@
-'use strict';
-
 export default function localStorageSink(todosData) {
   // Observe all todos data and save them to localStorage
   let savedTodosData = {

--- a/src/sources/todos.js
+++ b/src/sources/todos.js
@@ -1,4 +1,3 @@
-'use strict';
 import Cycle from 'cyclejs';
 
 function merge() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,3 @@
-'use strict';
-
 class PropertyHook {
   constructor(fn) {
     this.fn = fn;

--- a/src/views/todos.js
+++ b/src/views/todos.js
@@ -1,4 +1,3 @@
-'use strict';
 import Cycle from 'cyclejs';
 let {Rx, h} = Cycle;
 import {propHook} from '../utils';


### PR DESCRIPTION
Babel modules will implicitly add 'use strict'.
